### PR TITLE
Prevent level 5 kerbals from being chosen for training missions.

### DIFF
--- a/KerbalAcademyAdvancedPiloting.cfg
+++ b/KerbalAcademyAdvancedPiloting.cfg
@@ -27,7 +27,7 @@
 		{
 			type = Kerbal
 			uniquenessCheck = CONTRACT_ACTIVE
-			trainee = AllKerbals().Where(m => m.ExperienceTrait() == "Pilot" && m.Type() == Crew && m.RosterStatus() == Available && m.ExperienceLevel()>0).SelectUnique()
+			trainee = AllKerbals().Where(m => m.ExperienceTrait() == "Pilot" && m.Type() == Crew && m.RosterStatus() == Available && m.ExperienceLevel()>0 && m.ExperienceLevel()<5).SelectUnique()
 			title = Must have a Pilot available in the roster.
 		}
 

--- a/KerbalAcademyEngineeringSchool.cfg
+++ b/KerbalAcademyEngineeringSchool.cfg
@@ -27,7 +27,7 @@
 		{
 			type = Kerbal
 			uniquenessCheck = CONTRACT_ACTIVE
-			trainee = AllKerbals().Where(m => m.ExperienceTrait() == "Engineer" && m.Type() == Crew && m.RosterStatus() == Available && m.ExperienceLevel()>0).Random()
+			trainee = AllKerbals().Where(m => m.ExperienceTrait() == "Engineer" && m.Type() == Crew && m.RosterStatus() == Available && m.ExperienceLevel()>0 && m.ExperienceLevel()<5).Random()
 			title = Must have an engineer available in the roster.
 		}
 

--- a/KerbalAcademyFieldScience.cfg
+++ b/KerbalAcademyFieldScience.cfg
@@ -26,7 +26,7 @@
 		{
 			type = Kerbal
 			uniquenessCheck = CONTRACT_ACTIVE
-			trainee = AllKerbals().Where(m => m.ExperienceTrait() == "Scientist" && m.Type() == Crew && m.RosterStatus() == Available && m.ExperienceLevel()>0).Random()
+			trainee = AllKerbals().Where(m => m.ExperienceTrait() == "Scientist" && m.Type() == Crew && m.RosterStatus() == Available && m.ExperienceLevel()>0 && m.ExperienceLevel()<5).Random()
 			title = Must have a scientist who is level 1 or higher.
 		}
 


### PR DESCRIPTION
This should fix level 5 kerbals being picked for the experience boosting contracts.