### PR TITLE
Update KerbalAcademyAdvancedPiloting.cfg

### DIFF
--- a/KerbalAcademyAdvancedPiloting.cfg
+++ b/KerbalAcademyAdvancedPiloting.cfg
@@ -153,7 +153,7 @@
 	{
 		name = Expression
 		type = Expression
-		expression = (@/newLevel == 4)
+		expression = (@/newLevel == 4 && @/notMoon.Count() > 0)
 	}
 
 	REQUIREMENT
@@ -179,7 +179,7 @@
 	{
 		name = Expression
 		type = Expression
-		expression = (@/newLevel == 5)
+		expression = (@/newLevel == 5 && @/l5BodyList.Count() > 0)
 	}
 
 	REQUIREMENT


### PR DESCRIPTION
Advanced Piloting: Fix a situation when homeworld has not moons
Advanced Piloting: Fix a situation when already orbited bodies list is empty